### PR TITLE
Add Chrome extension for sniffing WebSocket traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# WebSocket Sniffer Chrome Extension
+
+This repository contains a Chrome extension that captures WebSocket activity from any tab and displays the events in an action popup.
+
+## Features
+
+- Hooks into page WebSocket objects to log lifecycle events and payloads.
+- Shows incoming, outgoing, open, close, and error events with timestamps.
+- Persists captured events via `chrome.storage` so the history is available while the extension is active.
+- Provides a popup UI with a running counter and the ability to clear logs.
+
+## Getting Started
+
+1. Clone this repository or download the source code.
+2. Open Chrome and navigate to `chrome://extensions`.
+3. Enable **Developer mode** (toggle in the top-right corner).
+4. Click **Load unpacked** and select the folder containing this project.
+5. Navigate to any website that uses WebSockets. The extension will automatically capture traffic for the active tab.
+6. Click the extension icon to open the popup and inspect captured events.
+
+## Development Notes
+
+- The extension injects a small script at `document_start` to wrap the native `WebSocket` constructor. This wrapper forwards lifecycle events and message payloads to the extension via `window.postMessage`.
+- The background service worker stores logs in `chrome.storage.local` and serves them to the popup on demand.
+- You can clear the history at any time from the popup using the **Clear** button.
+
+## Limitations
+
+- Binary payloads are summarized with their type and size rather than full contents.
+- Pages that redefine the global `WebSocket` constructor after our script runs might prevent logging.
+- The extension only inspects WebSocket usage initiated after the content script loads; existing connections opened before installation are not tracked.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,59 @@
+const STORAGE_KEY = 'wsLogs';
+let cache = [];
+
+async function loadCache() {
+  try {
+    const result = await chrome.storage.local.get({ [STORAGE_KEY]: [] });
+    cache = Array.isArray(result[STORAGE_KEY]) ? result[STORAGE_KEY] : [];
+  } catch (error) {
+    console.error('Failed to load WebSocket logs from storage', error);
+    cache = [];
+  }
+}
+
+async function persistCache() {
+  try {
+    await chrome.storage.local.set({ [STORAGE_KEY]: cache });
+  } catch (error) {
+    console.error('Failed to persist WebSocket logs', error);
+  }
+}
+
+loadCache();
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (!message || !message.type) {
+    return false;
+  }
+
+  if (message.type === 'WS_LOG') {
+    const entry = {
+      ...message.payload,
+      tabId: sender.tab ? sender.tab.id : null
+    };
+    cache.push(entry);
+    persistCache();
+    return false;
+  }
+
+  if (message.type === 'GET_LOGS') {
+    (async () => {
+      if (!cache.length) {
+        await loadCache();
+      }
+      sendResponse({ logs: cache });
+    })();
+    return true;
+  }
+
+  if (message.type === 'CLEAR_LOGS') {
+    (async () => {
+      cache = [];
+      await persistCache();
+      sendResponse({ success: true });
+    })();
+    return true;
+  }
+
+  return false;
+});

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,0 +1,175 @@
+(function init() {
+  injectHook();
+  setupBridge();
+
+  function injectHook() {
+    const scriptContent = `(${hookWebSocket.toString()})();`;
+    const script = document.createElement('script');
+    script.textContent = scriptContent;
+    (document.head || document.documentElement).appendChild(script);
+    script.remove();
+  }
+
+  function setupBridge() {
+    window.addEventListener('message', (event) => {
+      if (event.source !== window) {
+        return;
+      }
+
+      const data = event.data;
+      if (!data || data.source !== 'ws-sniffer') {
+        return;
+      }
+
+      chrome.runtime.sendMessage({
+        type: 'WS_LOG',
+        payload: data.payload
+      }).catch((error) => {
+        console.warn('Failed to forward WebSocket log', error);
+      });
+    });
+  }
+
+  function hookWebSocket() {
+    const serializeData = (input) => {
+      if (typeof input === 'string') {
+        return { kind: 'text', preview: input, size: input.length };
+      }
+
+      if (input instanceof ArrayBuffer) {
+        return { kind: 'arraybuffer', size: input.byteLength };
+      }
+
+      if (ArrayBuffer.isView(input)) {
+        return { kind: input.constructor.name, size: input.byteLength };
+      }
+
+      if (typeof Blob !== 'undefined' && input instanceof Blob) {
+        return { kind: 'blob', size: input.size, mimeType: input.type };
+      }
+
+      try {
+        const json = JSON.stringify(input);
+        return { kind: typeof input, preview: json, size: json.length };
+      } catch (error) {
+        return { kind: typeof input, preview: String(input) };
+      }
+    };
+
+    const post = (payload) => {
+      window.postMessage({ source: 'ws-sniffer', payload }, '*');
+    };
+
+    if (window.__WS_SNIFFER_INSTALLED__) {
+      return;
+    }
+    window.__WS_SNIFFER_INSTALLED__ = true;
+
+    const OriginalWebSocket = window.WebSocket;
+    if (!OriginalWebSocket) {
+      return;
+    }
+
+    const decorateSocket = (socket, args) => {
+      if (!socket || socket.__WS_SNIFFER_DECORATED__) {
+        return socket;
+      }
+
+      try {
+        const socketId = `ws-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+        const url = socket.url || (args && args[0]) || 'unknown';
+
+        Object.defineProperty(socket, '__WS_SNIFFER_DECORATED__', {
+          value: true,
+          enumerable: false,
+          configurable: false
+        });
+
+        post({
+          event: 'created',
+          socketId,
+          url,
+          time: Date.now()
+        });
+
+        socket.addEventListener('open', () => {
+          post({ event: 'open', socketId, url, time: Date.now() });
+        });
+
+        socket.addEventListener('close', (event) => {
+          post({
+            event: 'close',
+            socketId,
+            url,
+            code: event.code,
+            reason: event.reason,
+            wasClean: event.wasClean,
+            time: Date.now()
+          });
+        });
+
+        socket.addEventListener('error', () => {
+          post({ event: 'error', socketId, url, time: Date.now() });
+        });
+
+        socket.addEventListener('message', (event) => {
+          post({
+            event: 'incoming',
+            socketId,
+            url,
+            data: serializeData(event.data),
+            time: Date.now()
+          });
+        });
+
+        const originalSend = socket.send;
+        socket.send = function (...sendArgs) {
+          try {
+            post({
+              event: 'outgoing',
+              socketId,
+              url,
+              data: serializeData(sendArgs[0]),
+              time: Date.now()
+            });
+          } catch (error) {
+            console.warn('Failed to log outgoing WebSocket message', error);
+          }
+          return originalSend.apply(this, sendArgs);
+        };
+      } catch (error) {
+        console.warn('WebSocket sniffer failed to decorate socket', error);
+      }
+      return socket;
+    };
+
+    const WebSocketProxy = new Proxy(OriginalWebSocket, {
+      construct(target, args) {
+        const socket = new target(...args);
+        return decorateSocket(socket, args);
+      },
+      apply(target, thisArg, args) {
+        const socket = new target(...args);
+        return decorateSocket(socket, args);
+      }
+    });
+
+    WebSocketProxy.prototype = OriginalWebSocket.prototype;
+    try {
+      Object.setPrototypeOf(WebSocketProxy, OriginalWebSocket);
+    } catch (error) {
+      // Ignore if prototype cannot be set (older browsers).
+    }
+
+    ['CONNECTING', 'OPEN', 'CLOSING', 'CLOSED'].forEach((prop) => {
+      Object.defineProperty(WebSocketProxy, prop, {
+        value: OriginalWebSocket[prop],
+        writable: false,
+        configurable: true,
+        enumerable: true
+      });
+    });
+
+    window.WebSocket = WebSocketProxy;
+  }
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,22 @@
+{
+  "manifest_version": 3,
+  "name": "WebSocket Sniffer",
+  "version": "1.0.0",
+  "description": "Capture and inspect WebSocket traffic for the current tab.",
+  "permissions": ["storage"],
+  "host_permissions": ["<all_urls>"],
+  "action": {
+    "default_title": "WebSocket Sniffer",
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["contentScript.js"],
+      "run_at": "document_start"
+    }
+  ]
+}

--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,114 @@
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  padding: 0.75rem;
+  width: 420px;
+  max-height: 600px;
+  background: canvas;
+  color: canvastext;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+h1 {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+#clear {
+  appearance: none;
+  border: 1px solid color-mix(in srgb, canvastext 40%, transparent);
+  background: transparent;
+  padding: 0.25rem 0.6rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+#summary {
+  font-size: 0.9rem;
+  color: color-mix(in srgb, canvastext 60%, transparent);
+}
+
+#log-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow-y: auto;
+  padding-bottom: 0.5rem;
+}
+
+.log-entry {
+  border: 1px solid color-mix(in srgb, canvastext 25%, transparent);
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  background: color-mix(in srgb, canvas 92%, canvastext 8%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.log-entry header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.log-entry .event {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.log-entry .timestamp {
+  font-size: 0.75rem;
+  color: color-mix(in srgb, canvastext 60%, transparent);
+}
+
+.log-entry .meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.8rem;
+  color: color-mix(in srgb, canvastext 70%, transparent);
+}
+
+.log-entry .payload {
+  margin: 0;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: color-mix(in srgb, canvas 88%, canvastext 12%);
+  border-radius: 0.5rem;
+  padding: 0.4rem 0.5rem;
+}
+
+.log-entry[data-event='incoming'] {
+  border-color: #0f7bff55;
+}
+
+.log-entry[data-event='outgoing'] {
+  border-color: #ff7b0f55;
+}
+
+.log-entry[data-event='error'] {
+  border-color: #ff4d4f80;
+}
+
+.log-entry[data-event='close'] {
+  border-color: #8f8f8f55;
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>WebSocket Sniffer</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <header>
+      <h1>WebSocket Sniffer</h1>
+      <button id="clear">Clear</button>
+    </header>
+    <section id="summary">
+      <span id="count">0</span> events captured
+    </section>
+    <section id="log-list" role="list"></section>
+    <template id="log-entry">
+      <article class="log-entry" role="listitem">
+        <header>
+          <span class="event"></span>
+          <time class="timestamp"></time>
+        </header>
+        <div class="meta">
+          <span class="url"></span>
+          <span class="socket"></span>
+        </div>
+        <pre class="payload"></pre>
+      </article>
+    </template>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,80 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const logList = document.getElementById('log-list');
+  const count = document.getElementById('count');
+  const clearButton = document.getElementById('clear');
+  const template = document.getElementById('log-entry');
+
+  const render = (logs) => {
+    logList.innerHTML = '';
+    count.textContent = logs.length.toString();
+
+    logs
+      .slice()
+      .reverse()
+      .forEach((entry) => {
+        const clone = template.content.firstElementChild.cloneNode(true);
+        clone.dataset.event = entry.event;
+
+        clone.querySelector('.event').textContent = entry.event;
+        clone.querySelector('.timestamp').textContent = formatTime(entry.time);
+        clone.querySelector('.url').textContent = entry.url || 'unknown url';
+        clone.querySelector('.socket').textContent = `Socket: ${entry.socketId}`;
+        clone.querySelector('.payload').textContent = describePayload(entry);
+
+        logList.appendChild(clone);
+      });
+  };
+
+  const describePayload = (entry) => {
+    if (!entry.data) {
+      return '';
+    }
+
+    const { kind, preview, size, mimeType } = entry.data;
+    const sizeLabel = typeof size === 'number' ? ` (${size} bytes)` : '';
+
+    if (kind === 'text') {
+      return preview || '';
+    }
+
+    if (preview) {
+      return `${kind}${sizeLabel}: ${preview}`;
+    }
+
+    if (mimeType) {
+      return `${kind}${sizeLabel} - ${mimeType}`;
+    }
+
+    return `${kind || 'unknown'}${sizeLabel}`;
+  };
+
+  const formatTime = (timestamp) => {
+    try {
+      return new Date(timestamp).toLocaleTimeString();
+    } catch (error) {
+      return '';
+    }
+  };
+
+  const fetchLogs = () => {
+    chrome.runtime.sendMessage({ type: 'GET_LOGS' }, (response) => {
+      if (chrome.runtime.lastError) {
+        console.error('Failed to retrieve logs', chrome.runtime.lastError);
+        return;
+      }
+      render(response?.logs ?? []);
+    });
+  };
+
+  clearButton.addEventListener('click', () => {
+    chrome.runtime.sendMessage({ type: 'CLEAR_LOGS' }, () => {
+      if (chrome.runtime.lastError) {
+        console.error('Failed to clear logs', chrome.runtime.lastError);
+        return;
+      }
+      fetchLogs();
+    });
+  });
+
+  fetchLogs();
+});


### PR DESCRIPTION
## Summary
- add a Manifest V3 Chrome extension that captures WebSocket lifecycle events and payloads
- implement a background service worker that stores logs in chrome.storage and serves them to the popup
- provide a popup UI to review, summarize, and clear captured WebSocket messages

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d3b8229848832f8462c0b5a44c6a2e